### PR TITLE
Fix to work in batch mode

### DIFF
--- a/scripts/txt2mask.py
+++ b/scripts/txt2mask.py
@@ -128,7 +128,7 @@ class Script(scripts.Script):
 				transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
 				transforms.Resize((512, 512)),
 			])
-			img = transform(p.init_images[0]).unsqueeze(0)
+			img = transform(p.init_images[0].convert('RGB')).unsqueeze(0)
 
 			prompts = mask_prompt.split(delimiter_string)
 			prompt_parts = len(prompts)


### PR DESCRIPTION
I'm not sure if this messes anything else up, but this is what I needed to run this script in the batch mode. It was complaining with this error:

```
RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
```